### PR TITLE
OPS: add private handbook and payouts log

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+### Checklist
+- [ ] Sources and dates shown (No source, no ship)
+- [ ] Zero-click clarity preserved (or rationale)
+- [ ] If heuristic added: “Verification or Vapor” date (≤14 days)
+- [ ] If fairness gap ≥1.0 pp w/ support ≥30/week: freeze plan present
+- [ ] For SENTINEL receipts: ≤2 shown, 3 logged with block_hash; p95 budget ok
+- [ ] For TRIDENT answers: date-scoped, cited, p95 < 4 s

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing (Torchline Product)
+
+**Rails (non-negotiable):**
+- No source, no ship (every claim must show dated sources).
+- Zero-click clarity (fewer clicks than last iteration or explain why not).
+- Pilgrims only (scars over resumes); Death Sprints (4-day prove-or-kill).
+- Verification or Vapor: undocumented heuristics expire in ≤14 days unless source-verified.
+
+**Cadence:** Mon targets → Thu fragility mining → Fri demo (cite it or kill it).
+
+**How to add work:** Propose a user story under SENTINEL or TRIDENT with Outcomes, KPIs, ACs. Link to canon in `docs/canon/`.

--- a/archive/payouts.csv
+++ b/archive/payouts.csv
@@ -1,0 +1,1 @@
+date,pr,sha,amount,method,notes

--- a/docs/OPS.md
+++ b/docs/OPS.md
@@ -1,0 +1,1 @@
+# Torchline OPS (Private)\n- Scoring & payouts\n- Anti-cheat notes\n- Friday demo script

--- a/docs/roadmaps/README.md
+++ b/docs/roadmaps/README.md
@@ -1,0 +1,6 @@
+# Torchline Roadmaps (Source of Truth)
+
+- **SENTINEL** — Facilities: lift Dignity Minutes (DM%) via tiny, reversible, receipt-backed nudges. [Open](./SENTINEL.md)
+- **TRIDENT** — Families: enter aged care with cited, date-stamped answers. [Open](./TRIDENT.md)
+
+Canon lives in `docs/canon/` (Beliefs, Ignition, Stargaze Level-0, Trident brief).


### PR DESCRIPTION
Adds docs/OPS.md and archive/payouts.csv (private ops only).