### PR TITLE
Docs: add Fogbreaker MG2 ELI5 + issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/fogbreaker_mg2.md
+++ b/.github/ISSUE_TEMPLATE/fogbreaker_mg2.md
@@ -1,0 +1,17 @@
+---
+name: "MICRO-GRANT #2 — Fogbreaker Pulse v0.1"
+about: "Submission template for MG2"
+title: "MG2: <your handle> — Fogbreaker Pulse"
+labels: ["micro-grant","MG2","Fogbreaker"]
+assignees: ""
+---
+### Checklist
+- [ ] Base = glenmount/torchline-product:reset/scaffold
+- [ ] Only edited `fogbreaker-app/pulse/**`
+- [ ] `pulse/rankings/top10.json` has `generated_at`, `preset`, non-empty `ranked[]`, `providers[]`
+- [ ] (If receipts) `pulse/events.jsonl` is valid JSONL
+- [ ] (If receipts) `pulse/ledger/digest-YYYY-MM-DD.json` exists
+- [ ] Determinism verified (clean repo, run twice, bytes match)
+
+### Crusade Selfie (150–200 words)
+*What you built + how you proved determinism.*

--- a/docs/FOGBREAKER_MG2_ELI5.md
+++ b/docs/FOGBREAKER_MG2_ELI5.md
@@ -1,0 +1,14 @@
+# Fogbreaker — Micro Grant #2 (ELI5)
+Watch public docs → write a DeltaReceipt to `fogbreaker-app/pulse/events.jsonl` → re-rank → publish `fogbreaker-app/pulse/rankings/top10.json` → (optional) daily digest `pulse/ledger/digest-YYYY-MM-DD.json`.
+
+**DeltaReceipt (JSONL, one per line)**  
+{"observed_at":"2025-09-06T02:15:10Z","kind":"pricing_pdf","provider_id":"ACME-123","source":"fogbreaker-app/corpus/packs/ACME-123/pricing/2025-08.pdf","sha256":"...","size_bytes":184232,"rank_effect":2,"notes":"new pricing"}
+
+**Top-10 (minimal)**
+{"generated_at":"2025-09-06T02:15:55Z","preset":"Balanced","ranked":["ACME-123"],"providers":[{"provider_id":"ACME-123","score":87.4,"factors":{"cost":null,"cost_fit":0.5,"transparency":0,"quality":0,"policy":0}}]}
+
+**Rails:** allowed edits `fogbreaker-app/pulse/**`; no network; no PII; deterministic (same inputs → same bytes).  
+**Enter:** fork → checkout `reset/scaffold` → implement under `pulse/**` → PR with a 150–200 word “Crusade Selfie.”  
+**Acceptance:** re-rank provable (viewer “Updated” **or** new `generated_at` + order change), valid receipts, daily digest when receipts exist, determinism, path-confinement.  
+**Scoring (20):** Accuracy 8 • Receipts 4 • Determinism/Perf 4 • Code 4.  
+*Note: stale-stars penalty is out of scope for MG2 (Watchtowers phase).*


### PR DESCRIPTION
Adds entrant-facing docs:
- docs/FOGBREAKER_MG2_ELI5.md
- .github/ISSUE_TEMPLATE/fogbreaker_mg2.md

