### PR TITLE
Update validate-fogbreaker-pulse.yml

### DIFF
--- a/.github/workflows/validate-fogbreaker-pulse.yml
+++ b/.github/workflows/validate-fogbreaker-pulse.yml
@@ -1,43 +1,53 @@
-name: FOGBREAKER Pulse v0.1
+name: validate-fogbreaker-pulse
 
 on:
   pull_request:
     branches: ["reset/scaffold"]
+    paths:
+      - "fogbreaker-app/pulse/**"
+      - ".github/workflows/validate-fogbreaker-pulse.yml"
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  validate-pulse:
+  validate:
     name: Validate Micro-Grant — FOGBREAKER Pulse v0.1
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Enforce allowed paths (PR confinement)
-        if: ${{ github.event_name == 'pull_request' }}
+      # 1) Path confinement: only pulse/** (and this file)
+      - name: Path confinement (only fogbreaker-app/pulse/**)
         run: |
-          git fetch origin "${{ github.base_ref }}" --depth=1
-          CHANGED="$(git diff --name-only origin/${{ github.base_ref }}...HEAD || true)"
-          echo "$CHANGED"
-          ALLOWED='^(fogbreaker-app/corpus/|fogbreaker-app/pulse/|fogbreaker-app/services/fee_math/fee_math\.py$)'
+          set -euo pipefail
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          git fetch --no-tags --prune origin
+          CHANGED="$(git diff --name-only "$BASE_SHA"...HEAD || true)"
+          echo "Changed files:"; echo "${CHANGED:-<none>}"
+          ALLOWED='^(fogbreaker-app/pulse/|\.github/workflows/validate-fogbreaker-pulse\.yml$)'
           BAD=0
-          for f in $CHANGED; do
+          for f in ${CHANGED}; do
             if ! echo "$f" | grep -Eq "$ALLOWED"; then
-              echo "❌ Forbidden change: $f"
-              BAD=1
+              echo "❌ Forbidden change: $f"; BAD=1
             fi
           done
-          [ $BAD -eq 0 ] || { echo "Only fogbreaker-app/{corpus|pulse} or fee_math.py allowed."; exit 1; }
+          [ $BAD -eq 0 ] || { echo "Only fogbreaker-app/pulse/** allowed."; exit 1; }
           echo "✅ Allowed paths only."
 
-      - name: Validate Pulse artifacts & replay
+      # 2) Detect if pulse/** changed (so maintenance PRs can pass)
+      - name: Detect if pulse files changed
+        id: pulse_changed
         run: |
-          set -e
-          test -f fogbreaker-app/pulse/rankings/top10.json
-          [ -f fogbreaker-app/pulse/events.jsonl ] || echo "⚠ events.jsonl missing (OK if your pulse creates it)"
-          python - <<'PY'
-          import json
-          with open("fogbreaker-app/pulse/rankings/top10.json", encoding="utf-8") as f:
-            j = json.load(f)
-          assert isinstance(j.get("ranked"), list) and j["ranked"], "rankings/top10.json must have a non-empty 'ranked' list"
-          print("✅ Ranking output present with", len(j["ranked"]), "providers.")
-          PY
+          set -euo pipefail
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          git fetch --no-tags --prune origin
+          CHANGED="$(git diff --name-only "$BASE

--- a/.github/workflows/validate-fogbreaker-pulse.yml
+++ b/.github/workflows/validate-fogbreaker-pulse.yml
@@ -51,3 +51,4 @@ jobs:
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
           git fetch --no-tags --prune origin
           CHANGED="$(git diff --name-only "$BASE
+  


### PR DESCRIPTION
### FOGBREAKER — Pulse v0.1 Checklist
- [ ] Paths confined to allowed folders
- [ ] Live Top-10 shows cost / stars / audit / freshness / missingness
- [ ] DAP receipts for all 10 (≥1 scenario each; Decimal HALF_UP)
- [ ] pulse/events.jsonl grows; pulse/ledger/digest-YYYY-MM-DD.json present
- [ ] Delta Receipt appears when a watched file changes
- [ ] Ranking preset chosen: Budget-first | Balanced | Safety-first
- [ ] Hard floor/penalties applied and visible
- [ ] Fog Pack export (docs + last-7-day deltas + Top-3 summary; **no PII**)
- [ ] Day-3 Two-Provider Proof included

### Crusade Selfie (~200 words)
Why you burn for this; scars > CV.
